### PR TITLE
Allow transferFrom(this, ...) by default

### DIFF
--- a/src/base.sol
+++ b/src/base.sol
@@ -35,21 +35,17 @@ contract DSTokenBase is ERC20, DSMath {
     }
     
     function transfer(address dst, uint wad) returns (bool) {
-        require(_balances[msg.sender] >= wad);
-        
-        _balances[msg.sender] = sub(_balances[msg.sender], wad);
-        _balances[dst] = add(_balances[dst], wad);
-        
-        Transfer(msg.sender, dst, wad);
-        
-        return true;
+        return transferFrom(msg.sender, dst, wad);
     }
     
     function transferFrom(address src, address dst, uint wad) returns (bool) {
         require(_balances[src] >= wad);
-        require(_approvals[src][msg.sender] >= wad);
-        
-        _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+
+        if (src != msg.sender) {
+            require(_approvals[src][msg.sender] >= wad);
+            _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+        }
+
         _balances[src] = sub(_balances[src], wad);
         _balances[dst] = add(_balances[dst], wad);
         

--- a/src/token.sol
+++ b/src/token.sol
@@ -38,8 +38,8 @@ contract DSToken is DSTokenBase(0), DSStop {
         Trust(msg.sender, guy, wat);
     }
 
-    function transfer(address dst, uint wad) stoppable returns (bool) {
-        return super.transfer(dst, wad);
+    function approve(address guy, uint wad) stoppable returns (bool) {
+        return super.approve(guy, wad);
     }
     function transferFrom(address src, address dst, uint wad)
         stoppable
@@ -47,7 +47,7 @@ contract DSToken is DSTokenBase(0), DSStop {
     {
         require(_balances[src] >= wad);
 
-        if (!_trusted[src][msg.sender]) {
+        if (src != msg.sender && !_trusted[src][msg.sender]) {
             require(_approvals[src][msg.sender] >= wad);
             _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
         }
@@ -59,12 +59,9 @@ contract DSToken is DSTokenBase(0), DSStop {
 
         return true;
     }
-    function approve(address guy, uint wad) stoppable returns (bool) {
-        return super.approve(guy, wad);
-    }
 
     function push(address dst, uint wad) {
-        transfer(dst, wad);
+        transferFrom(msg.sender, dst, wad);
     }
     function pull(address src, uint wad) {
         transferFrom(src, msg.sender, wad);

--- a/src/token.t.sol
+++ b/src/token.t.sol
@@ -158,6 +158,12 @@ contract DSTokenTest is DSTest {
         user1.doApprove(self, 20);
         token.transferFrom(user1, self, 21);
     }
+    function testTransferFromSelf() {
+        // you always trust yourself
+        assertTrue(!token.trusted(this, this));
+        token.transferFrom(this, user1, 50);
+        assertEq(token.balanceOf(user1), 50);
+    }
 
     function testMint() {
         uint mintAmount = 10;


### PR DESCRIPTION
Users / contracts should always be able to use `transferFrom` from themselves,
without setting approval or trust first.

Then `transfer` can just be defined as

```
function transfer(address guy, uint wad) {
    transferFrom(msg.sender, guy, wad);
}
```

The following illustrates some nuances of this change:

```
// example of default-self-approval causing problems
contract UserVault is DSAuth {
    DSToken token;

    function allow(uint amount) auth {
        token.approve(this, amount);
    }
    // previously, this would be limited by the approval set by `allow`,
    // but with default-self-approval any amount can be withdrawn
    function withdraw(uint amount) {
        token.transferFrom(this, msg.sender, amount);
    }
}
```

```
// how to properly implement this in default-self-approve world
contract SaneUserVault is DSAuth {
    DSToken token;
    uint allowed;

    function allow(uint amount) auth {
        allowed = amount;
    }
    function withdraw(uint amount) {
        require(amount <= allowed);
        allowed = sub(allowed, amount);      // sub is overflow safe
        token.transfer(msg.sender, amount);
    }
}
```