### PR TITLE
Use string for name and symbol

### DIFF
--- a/src/token.sol
+++ b/src/token.sol
@@ -26,11 +26,12 @@ contract DSToken is DSMath, DSAuth {
     uint256                                           public  totalSupply;
     mapping (address => uint256)                      public  balanceOf;
     mapping (address => mapping (address => uint256)) public  allowance;
-    bytes32                                           public  symbol;
+    string                                            public  symbol;
     uint8                                             public  decimals = 18; // standard token precision. override to customize
-    bytes32                                           public  name = "";     // Optional token name
+    string                                            public  name = "";     // Optional token name
 
-    constructor(bytes32 symbol_) public {
+
+    constructor(string memory symbol_) public {
         symbol = symbol_;
     }
 
@@ -130,7 +131,8 @@ contract DSToken is DSMath, DSAuth {
         emit Start();
     }
 
-    function setName(bytes32 name_) external auth {
+
+    function setName(string memory name_) public auth {
         name = name_;
     }
 }

--- a/src/token.t.sol
+++ b/src/token.t.sol
@@ -61,7 +61,7 @@ contract TokenUser {
         return token.balanceOf(who);
     }
 
-    function doSetName(bytes32 name) public {
+    function doSetName(string memory name) public {
         token.setName(name);
     }
 


### PR DESCRIPTION
Recent versions of `solc` do not treat `bytes32` and `string` in the same way that it used to, they are no longer comparable or directly castable. Therefore, creating token integrations with more recent versions of `solc` have difficulty processing the DS-Token's `bytes32` return from `name` and `string`. The ERC20 standard does call for `string` types to be used for these optional returns so I'm just putting this forth as a suggestion.