### PR TITLE
Convert decimals to uint8 for standards conformance.

### DIFF
--- a/src/token.sol
+++ b/src/token.sol
@@ -27,7 +27,7 @@ contract DSToken is DSMath, DSAuth {
     mapping (address => uint256)                      public  balanceOf;
     mapping (address => mapping (address => uint256)) public  allowance;
     bytes32                                           public  symbol;
-    uint256                                           public  decimals = 18; // standard token precision. override to customize
+    uint8                                             public  decimals = 18; // standard token precision. override to customize
     bytes32                                           public  name = "";     // Optional token name
 
     constructor(bytes32 symbol_) public {


### PR DESCRIPTION
`decimals()` should return `uint8` according to [ERC20 standard](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#decimals)

Updates the variable here to match.