### PR TITLE
chore: tighten pragma

### DIFF
--- a/src/token.sol
+++ b/src/token.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23;
+pragma solidity >=0.4.23 <0.7.0;
 
 import "ds-math/math.sol";
 import "ds-auth/auth.sol";


### PR DESCRIPTION
As-is, the code will not work with any version after 0.7.0 (inclusive).

* `>=0.7.0` errors due to usage of `now` which has been deprecated in favor of `block.timestamp`
* `>=0.8.0` errors due to:
    * `type conversion from "int_const -1" to "uint256"`, which can be replaced with `type(uint256).max`
    * `type conversion from int_const 0" to "contract DSAuthority"`