### PR TITLE
fix: allow to be compatible with solc 0.8.x

### DIFF
--- a/src/token.sol
+++ b/src/token.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23 <0.7.0;
+pragma solidity >=0.4.23;
 
 import "ds-math/math.sol";
 import "ds-auth/auth.sol";
@@ -48,7 +48,7 @@ contract DSToken is DSMath, DSAuth {
     }
 
     function approve(address guy) external returns (bool) {
-        return approve(guy, uint(-1));
+        return approve(guy, type(uint).max);
     }
 
     function approve(address guy, uint wad) public stoppable returns (bool) {
@@ -68,7 +68,7 @@ contract DSToken is DSMath, DSAuth {
         stoppable
         returns (bool)
     {
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint).max) {
             require(allowance[src][msg.sender] >= wad, "ds-token-insufficient-approval");
             allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
         }
@@ -110,7 +110,7 @@ contract DSToken is DSMath, DSAuth {
     }
 
     function burn(address guy, uint wad) public auth stoppable {
-        if (guy != msg.sender && allowance[guy][msg.sender] != uint(-1)) {
+        if (guy != msg.sender && allowance[guy][msg.sender] != type(uint).max) {
             require(allowance[guy][msg.sender] >= wad, "ds-token-insufficient-approval");
             allowance[guy][msg.sender] = sub(allowance[guy][msg.sender], wad);
         }

--- a/src/token.t.sol
+++ b/src/token.t.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.23 <0.7.0;
+pragma solidity >=0.4.23;
 
 import "ds-test/test.sol";
 
@@ -315,7 +315,7 @@ contract DSTokenTest is DSTest {
     function testTrusting() public {
         assertEq(token.allowance(self, user2), 0);
         token.approve(user2);
-        assertEq(token.allowance(self, user2), uint(-1));
+        assertEq(token.allowance(self, user2), type(uint).max);
         token.approve(user2, 0);
         assertEq(token.allowance(self, user2), 0);
     }
@@ -363,10 +363,10 @@ contract DSTokenTest is DSTest {
         assertEq(token.allowance(self, user1), 0);
         assertEq(token.balanceOf(user1), 0);
         token.approve(user1);
-        assertEq(token.allowance(self, user1), uint(-1));
+        assertEq(token.allowance(self, user1), type(uint).max);
         TokenUser(user1).doPull(self, 1000);
         assertEq(token.balanceOf(user1), 1000);
-        assertEq(token.allowance(self, user1), uint(-1));
+        assertEq(token.allowance(self, user1), type(uint).max);
     }
 
     function testFailTransferOnlyTrustedCaller() public {


### PR DESCRIPTION
* replace usages of uint(-1) with type(uint).max
* loosen pragma
* for more info, see https://docs.soliditylang.org/en/breaking/080-breaking-changes.html#new-restrictions